### PR TITLE
Fix server startup issues

### DIFF
--- a/codeninja-server.js
+++ b/codeninja-server.js
@@ -1,6 +1,7 @@
 // n8n-workflow-editor-mcp-server.js
 import { Server } from '@modelcontextprotocol/sdk/server/index.js';
 import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { ListToolsRequestSchema, CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
 import axios from 'axios';
 
 // Configuration
@@ -21,6 +22,10 @@ const server = new Server({
   name: 'n8n-workflow-editor',
   version: '1.0.0',
   description: 'MCP server for programmatically editing n8n workflows'
+}, {
+  capabilities: {
+    tools: {}
+  }
 });
 
 // Tool definitions
@@ -384,11 +389,11 @@ const tools = [
   }
 ];
 
-// Register tools
-server.setRequestHandler('tools/list', async () => ({ tools }));
+// Register tools using MCP schemas
+server.setRequestHandler(ListToolsRequestSchema, async () => ({ tools }));
 
 // Tool implementations
-server.setRequestHandler('tools/call', async (request) => {
+server.setRequestHandler(CallToolRequestSchema, async (request) => {
   const { name, arguments: args } = request.params;
 
   try {

--- a/start-ninja.sh
+++ b/start-ninja.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 export N8N_URL="http://localhost:5678"
-export N8N_API_KEY= "$N8N_API_KEY"
+export N8N_API_KEY="$N8N_API_KEY"
 export N8N_WEBHOOK_URL="http://localhost:5678"
 echo "🥷 CodeNinja Connected to Third Eye Diagnostics!"
 node codeninja-server.js


### PR DESCRIPTION
## Summary
- fix N8N_API_KEY export in `start-ninja.sh`
- register tool handlers with MCP schemas
- enable tool capability for the server

## Testing
- `node codeninja-server.js` *(server started)*
- `bash ./start-ninja.sh` *(server started)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854b860530c8328b0f3f11f293bab06