### PR TITLE
Add workflow activation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ npm start
 - `list_workflows` - List all workflows
 - `get_workflow` - Get workflow details
 - `create_workflow` - Create new workflow
+- `activate_workflow` - Deploy and activate a workflow
 - `execute_workflow` - Run a workflow
 
 </details>

--- a/codeninja-server.js
+++ b/codeninja-server.js
@@ -68,10 +68,10 @@ const tools = [
     inputSchema: {
       type: 'object',
       properties: {
-        name: { 
-          type: 'string', 
+        name: {
+          type: 'string',
           description: 'Workflow name',
-          required: true 
+          required: true
         },
         nodes: {
           type: 'array',
@@ -81,7 +81,7 @@ const tools = [
             properties: {
               name: { type: 'string' },
               type: { type: 'string' },
-              position: { 
+              position: {
                 type: 'array',
                 items: { type: 'number' }
               },
@@ -92,9 +92,28 @@ const tools = [
         connections: {
           type: 'object',
           description: 'Node connections'
+        },
+        activate: {
+          type: 'boolean',
+          description: 'Activate the workflow after creation'
         }
       },
       required: ['name']
+    }
+  },
+  {
+    name: 'activate_workflow',
+    description: 'Activate (deploy) an existing workflow',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        workflowId: {
+          type: 'string',
+          description: 'Workflow ID',
+          required: true
+        }
+      },
+      required: ['workflowId']
     }
   },
   {
@@ -448,12 +467,26 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
           active: false,
           settings: {}
         };
-        
+
         const response = await api.post('/workflows', workflowData);
+        if (args.activate) {
+          await api.post(`/workflows/${response.data.id}/activate`);
+        }
+
         return {
           content: [{
             type: 'text',
-            text: `Workflow created successfully!\nID: ${response.data.id}\nName: ${response.data.name}`
+            text: `Workflow created successfully!\nID: ${response.data.id}\nName: ${response.data.name}${args.activate ? '\nActivated: true' : ''}`
+          }]
+        };
+      }
+
+      case 'activate_workflow': {
+        await api.post(`/workflows/${args.workflowId}/activate`);
+        return {
+          content: [{
+            type: 'text',
+            text: `Workflow ${args.workflowId} activated`,
           }]
         };
       }


### PR DESCRIPTION
## Summary
- document `activate_workflow` tool in README
- support optional `activate` flag when creating workflows
- add new tool and handler to activate workflows

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6854b98e5d3483288a98546d3196afb2